### PR TITLE
If Box that does not define the schema is included when executing sl …

### DIFF
--- a/pcui.rb
+++ b/pcui.rb
@@ -253,6 +253,9 @@ class Cell
 	end
 
 	def list_formating(update_t, name, schema)
+		if(schema.nil?)
+			schema = ''
+		end
 		return (update_t + "\t" + name  + "\t" + schema)
 	end
 end


### PR DESCRIPTION
…command of Cell mode which is Box 's simple list display function, an exception occurs in string concatenation.

To avoid this, when it was null, it was fixed not to display the schema definition.